### PR TITLE
Change how big integers are calculated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
 	],
 	"require": {
 		"php": ">=7.1",
+		"ext-bcmath": "*",
 		"illuminate/contracts": "^5.5|^5.6",
 		"illuminate/support": "^5.5|^5.6",
 		"illuminate/validation": "^5.5|^5.6"

--- a/src/BigInteger.php
+++ b/src/BigInteger.php
@@ -2,25 +2,41 @@
 
 class BigInteger extends BaseMysqlIntegerRule
 {
-	/**
-	 * @return int
-	 */
-	protected function min() {
-		if ( $this->unsigned ) {
-			return 0;
-		}
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string $attribute
+     * @param  mixed  $value
+     *
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return bccomp($value, $this->min) >= 0
+            && bccomp($value, $this->max) <= 0;
+    }
 
-		return -2 ^ 63;
-	}
+    /**
+     * @return int
+     */
+    protected function min()
+    {
+        if ($this->unsigned) {
+            return 0;
+        }
 
-	/**
-	 * @return int
-	 */
-	protected function max() {
-		if ( $this->unsigned ) {
-			return 2 ^ 64 - 1;
-		}
+        return bcpow(-2, 63);
+    }
 
-		return 2 ^ 63 - 1;
-	}
+    /**
+     * @return int
+     */
+    protected function max()
+    {
+        if ($this->unsigned) {
+            return bcsub(bcpow(2, 64), 1);
+        }
+
+        return bcsub(bcpow(2, 63), 1);
+    }
 }

--- a/tests/BigIntegerValidationTest.php
+++ b/tests/BigIntegerValidationTest.php
@@ -4,27 +4,32 @@ use PHPUnit\Framework\TestCase;
 
 class BigIntegerValidationTest extends TestCase
 {
-	/** @test */
-	public function can_validate_signed_big_integers() {
-		$rule = new \Rackbeat\Rules\BigInteger( false );
+    /** @test */
+    public function can_validate_signed_big_integers()
+    {
+        $rule = new \Rackbeat\Rules\BigInteger(false);
+        $min = '-9223372036854775808';
+        $max = '9223372036854775807';
 
-		$this->assertTrue( $rule->passes( 'number', 0 ) );
-		$this->assertTrue( $rule->passes( 'number', -2 ^ 63 ) );
-		$this->assertTrue( $rule->passes( 'number', 2 ^ 63 - 1 ) );
+        $this->assertTrue($rule->passes('number', 0));
+        $this->assertTrue($rule->passes('number', $min));
+        $this->assertTrue($rule->passes('number', $max));
 
-		$this->assertFalse( $rule->passes( 'number', -5000000000000000000 ) );
-		$this->assertFalse( $rule->passes( 'number', 50000000000000000000 ) );
-	}
+        $this->assertFalse($rule->passes('number', bcsub($min, 1)));
+        $this->assertFalse($rule->passes('number', bcadd($max, 1)));
+    }
 
-	/** @test */
-	public function can_validate_unsigned_big_integers() {
-		$rule = new \Rackbeat\Rules\BigInteger( true );
+    /** @test */
+    public function can_validate_unsigned_big_integers()
+    {
+        $rule = new \Rackbeat\Rules\BigInteger(true);
+        $min = 0;
+        $max = '18446744073709551615';
 
-		$this->assertTrue( $rule->passes( 'number', 0 ) );
-		$this->assertTrue( $rule->passes( 'number', 2 ^ 64 - 1 ) );
+        $this->assertTrue($rule->passes('number', $min));
+        $this->assertTrue($rule->passes('number', $max));
 
-		$this->assertFalse( $rule->passes( 'number', -2147483648 ) );
-		$this->assertFalse( $rule->passes( 'number', -50000000000000000000 ) );
-		$this->assertFalse( $rule->passes( 'number', 50000000000000000000 ) );
-	}
+        $this->assertFalse($rule->passes('number', $min - 1));
+        $this->assertFalse($rule->passes('number', bcadd($max, 1)));
+    }
 }


### PR DESCRIPTION
### About
As pointed out in #1, the caret (`^`) is used as the bitwise XOR instead of for exponention.

This PR corrects that, and also changes the calculations to utilize BC Math for extended nubmer precision, so that we are sure that the given values do not "roll over"/overflow to a rounded `double` or similar.

### Changes
- [x] Utilize hardcoded min/max in test case
- [x] Override the parent `passes()`-method to use `bccomp()` for comparison
- [x] Utilize `bcpow()` and `bcsub()` to calculate precise `min()` and `max()` values