### PR TITLE
Update validation error message to use min and max values

### DIFF
--- a/src/BaseMysqlIntegerRule.php
+++ b/src/BaseMysqlIntegerRule.php
@@ -46,6 +46,6 @@ abstract class BaseMysqlIntegerRule implements Rule
 	 * @return string
 	 */
 	public function message() {
-		return ':attribute must be between :min and :max.';
+		return ':attribute must be between ' . $this->min . ' and ' . $this->max . '.';
 	}
 }


### PR DESCRIPTION
:min and :max are never actually substituted in because they aren't params to the rule